### PR TITLE
hepipe-janus.js: returns when correlation_id is a number

### DIFF
--- a/janus/hepipe-janus.js
+++ b/janus/hepipe-janus.js
@@ -98,7 +98,7 @@ var preHep = function(message) {
 
 	var rcinfo = message.rcinfo;
 	var msg = message.payload;
-	if (rcinfo.correlation_id == null || ! rcinfo.correlation_id.length ) return;
+	if (rcinfo.correlation_id == null || !(rcinfo.correlation_id.toString().length)) return;
 	if (debug) console.log(msg);
 	stats.rcvd++;
 


### PR DESCRIPTION
A minor change to prevent cases where the correlation_id is numeric and it's incorrectly interpreted as an empty string and skip the message.