### PR TITLE
Ignore events from calls not in db

### DIFF
--- a/esl-client.js
+++ b/esl-client.js
@@ -282,6 +282,13 @@ var eslConnect = function (host, port, pass, callback_preHep) {
 var getRTCPMessage = function (e, xcid, hep_id, hep_pass) {
   var call = db.get(e.getHeader("Unique-ID"));
 
+  // Ignore RTCP events for calls that aren't in the database. This can happen
+  // if hepipe is just starting up but the telephony service already has calls
+  // in progress.
+  if (!call) {
+    return;
+  }
+
   if (e.getHeader("Event-Name") == "RECV_RTCP_MESSAGE") {
     if (!call.recvSSRC) {
       call.recvSSRC = e.getHeader("Source0-SSRC");

--- a/esl-client.js
+++ b/esl-client.js
@@ -1,17 +1,17 @@
 /*
-*	HEPIPE-ESL 0.1
-*	FreeSWITCH ESL to HEP/EEP Utility
-*	Copyright 2016 QXIP BV (http://qxip.net)
-*
-* Edited by:
-* Giacomo Vacca <giacomo.vacca@gmail.com>
-* Federico Cabibbu <federico.cabiddu@gmail.com>
-*/
+ *	HEPIPE-ESL 0.1
+ *	FreeSWITCH ESL to HEP/EEP Utility
+ *	Copyright 2016 QXIP BV (http://qxip.net)
+ *
+ * Edited by:
+ * Giacomo Vacca <giacomo.vacca@gmail.com>
+ * Federico Cabibbu <federico.cabiddu@gmail.com>
+ */
 
 var eslWaitTime = 60000;
 var debug = false;
 
-var Receptacle = require('receptacle');
+var Receptacle = require("receptacle");
 var db = new Receptacle({ max: 1048576 });
 
 var report_call_events = false;
@@ -23,7 +23,7 @@ var log = true;
 var hep_id;
 var hep_pass;
 
-var esl = require('modesl');
+var esl = require("modesl");
 
 var ttl = { ttl: 86400000 };
 
@@ -40,144 +40,211 @@ module.exports = {
     report_custom_events = config.report_custom_events;
     debug = config.debug;
     eslConnect(host, port, pass, callback_preHep);
-  }
+  },
 };
 
 var eslConnect = function (host, port, pass, callback_preHep) {
-  if (debug) console.log("host: " + host + ", port: " + port + ", pass: " + pass);
+  if (debug)
+    console.log("host: " + host + ", port: " + port + ", pass: " + pass);
 
   eslConn = new esl.Connection(host, port, pass)
     .on("error", function (error) {
-      console.log('ESL Connection Error ' + JSON.stringify(error));
-      setTimeout(function () { eslConnect(host, port, pass, callback_preHep); }, eslWaitTime);
-    }).on("esl::end", function () {
-      console.log('ESL Connection Ended');
-      setTimeout(function () { eslConnect(host, port, pass, callback_preHep); }, eslWaitTime);
-    }).on("esl::ready", function () {
-      eslConn.events('json', 'ALL', function () {
-        console.log('ESL ready - subscribed to receive events.');
+      console.log("ESL Connection Error " + JSON.stringify(error));
+      setTimeout(function () {
+        eslConnect(host, port, pass, callback_preHep);
+      }, eslWaitTime);
+    })
+    .on("esl::end", function () {
+      console.log("ESL Connection Ended");
+      setTimeout(function () {
+        eslConnect(host, port, pass, callback_preHep);
+      }, eslWaitTime);
+    })
+    .on("esl::ready", function () {
+      eslConn.events("json", "ALL", function () {
+        console.log("ESL ready - subscribed to receive events.");
       });
-    }).on("esl::event::**", function (e, headers, body) {
-      if (debug) console.log('Event: ' + e.getHeader('Event-Name'));
-      if (debug) console.log('Unique-ID: ' + e.getHeader('Unique-ID'));
+    })
+    .on("esl::event::**", function (e, headers, body) {
+      if (debug) console.log("Event: " + e.getHeader("Event-Name"));
+      if (debug) console.log("Unique-ID: " + e.getHeader("Unique-ID"));
 
       if (db) {
-        if (db.get(e.getHeader('Other-Leg-Unique-ID'))) {
-          if (debug) console.log('FOUND B-LEG!', db.get(e.getHeader('Other-Leg-Unique-ID')).cid);
-          var xcid = db.get(e.getHeader('Other-Leg-Unique-ID')).cid;
-        } else if (db.get(e.getHeader('Unique-ID'))) {
-          if (debug) console.log('FOUND!', db.get(e.getHeader('Unique-ID')).cid);
-          var xcid = db.get(e.getHeader('Unique-ID')).cid;
+        if (db.get(e.getHeader("Other-Leg-Unique-ID"))) {
+          if (debug)
+            console.log(
+              "FOUND B-LEG!",
+              db.get(e.getHeader("Other-Leg-Unique-ID")).cid
+            );
+          var xcid = db.get(e.getHeader("Other-Leg-Unique-ID")).cid;
+        } else if (db.get(e.getHeader("Unique-ID"))) {
+          if (debug)
+            console.log("FOUND!", db.get(e.getHeader("Unique-ID")).cid);
+          var xcid = db.get(e.getHeader("Unique-ID")).cid;
         } else {
-          if (debug) console.log('DEFAULT!', db.get(e.getHeader('variable_sip_call_id')));
-          var xcid = e.getHeader('variable_sip_call_id');
+          if (debug)
+            console.log(
+              "DEFAULT!",
+              db.get(e.getHeader("variable_sip_call_id"))
+            );
+          var xcid = e.getHeader("variable_sip_call_id");
         }
-      } else { var xcid = e.getHeader('variable_sip_call_id'); }
+      } else {
+        var xcid = e.getHeader("variable_sip_call_id");
+      }
 
       if (log) {
-        var payload = e.getHeader('Event-Date-Local') + ': ';
-        if (e.getHeader('Event-Name')) {
-          if (e.getHeader('Event-Name') == 'CHANNEL_CREATE') {
-            if (e.getHeader('Call-Direction') == 'inbound') {
-              payload += 'RINGING; ';
-              payload += e.getHeader('Call-Direction') + '; ';
-              payload += e.getHeader('Caller-Caller-ID-Number') + '; ';
-              payload += e.getHeader('Caller-Destination-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+        var payload = e.getHeader("Event-Date-Local") + ": ";
+        if (e.getHeader("Event-Name")) {
+          if (e.getHeader("Event-Name") == "CHANNEL_CREATE") {
+            if (e.getHeader("Call-Direction") == "inbound") {
+              payload += "RINGING; ";
+              payload += e.getHeader("Call-Direction") + "; ";
+              payload += e.getHeader("Caller-Caller-ID-Number") + "; ";
+              payload += e.getHeader("Caller-Destination-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             } else {
-              payload += 'RINGING; ';
-              payload += e.getHeader('Call-Direction') + '; ';
-              payload += e.getHeader('Caller-Callee-ID-Number') + '; ';
-              payload += e.getHeader('Caller-Caller-ID-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+              payload += "RINGING; ";
+              payload += e.getHeader("Call-Direction") + "; ";
+              payload += e.getHeader("Caller-Callee-ID-Number") + "; ";
+              payload += e.getHeader("Caller-Caller-ID-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             }
 
-            db.set(e.getHeader('Unique-ID'), { cid: e.getHeader('variable_sip_call_id') }, ttl);
-          } else if (e.getHeader('Event-Name') == 'CHANNEL_PROGRESS_MEDIA') {
-            var key = e.getHeader('Unique-ID');
+            db.set(
+              e.getHeader("Unique-ID"),
+              { cid: e.getHeader("variable_sip_call_id") },
+              ttl
+            );
+          } else if (e.getHeader("Event-Name") == "CHANNEL_PROGRESS_MEDIA") {
+            var key = e.getHeader("Unique-ID");
             var details = {
-              cid: e.getHeader('variable_sip_call_id'),
-              localMediaIp: e.getHeader('variable_local_media_ip'),
-              remoteMediaIp: e.getHeader('variable_remote_media_ip'),
-              localMediaPort: e.getHeader('variable_local_media_port'),
-              remoteMediaPort: e.getHeader('variable_remote_media_port')
+              cid: e.getHeader("variable_sip_call_id"),
+              localMediaIp: e.getHeader("variable_local_media_ip"),
+              remoteMediaIp: e.getHeader("variable_remote_media_ip"),
+              localMediaPort: e.getHeader("variable_local_media_port"),
+              remoteMediaPort: e.getHeader("variable_remote_media_port"),
             };
-            if (debug) console.log(`CHANNEL_PROGRESS_MEDIA SETTING CACHE FOR ${key} TO ${JSON.stringify(details)}`);
+            if (debug)
+              console.log(
+                `CHANNEL_PROGRESS_MEDIA SETTING CACHE FOR ${key} TO ${JSON.stringify(
+                  details
+                )}`
+              );
             db.set(key, details, ttl);
-          } else if (e.getHeader('Event-Name') == 'CHANNEL_BRIDGE') {
-            var key = e.getHeader('Unique-ID');
+          } else if (e.getHeader("Event-Name") == "CHANNEL_BRIDGE") {
+            var key = e.getHeader("Unique-ID");
             var details = {
-              cid: e.getHeader('variable_sip_call_id'),
-              localMediaIp: e.getHeader('variable_local_media_ip'),
-              remoteMediaIp: e.getHeader('variable_remote_media_ip'),
-              localMediaPort: e.getHeader('variable_local_media_port'),
-              remoteMediaPort: e.getHeader('variable_remote_media_port')
+              cid: e.getHeader("variable_sip_call_id"),
+              localMediaIp: e.getHeader("variable_local_media_ip"),
+              remoteMediaIp: e.getHeader("variable_remote_media_ip"),
+              localMediaPort: e.getHeader("variable_local_media_port"),
+              remoteMediaPort: e.getHeader("variable_remote_media_port"),
             };
-            if (debug) console.log(`CHANNEL_BRIDGE SETTING CACHE FOR ${key} TO ${JSON.stringify(details)}`);
+            if (debug)
+              console.log(
+                `CHANNEL_BRIDGE SETTING CACHE FOR ${key} TO ${JSON.stringify(
+                  details
+                )}`
+              );
             db.set(key, details, ttl);
-          } else if (e.getHeader('Event-Name') == 'CHANNEL_ANSWER') {
-            if (e.getHeader('Call-Direction') == 'inbound') {
-              payload += 'ANSWERED; ';
-              payload += e.getHeader('Caller-Caller-ID-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+          } else if (e.getHeader("Event-Name") == "CHANNEL_ANSWER") {
+            if (e.getHeader("Call-Direction") == "inbound") {
+              payload += "ANSWERED; ";
+              payload += e.getHeader("Caller-Caller-ID-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             } else {
-              payload += 'ANSWERED; ';
-              payload += e.getHeader('Caller-Callee-ID-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+              payload += "ANSWERED; ";
+              payload += e.getHeader("Caller-Callee-ID-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             }
 
-            var key = e.getHeader('Unique-ID');
+            var key = e.getHeader("Unique-ID");
             var details = {
-              cid: e.getHeader('variable_sip_call_id'),
-              localMediaIp: e.getHeader('variable_local_media_ip'),
-              remoteMediaIp: e.getHeader('variable_remote_media_ip'),
-              localMediaPort: e.getHeader('variable_local_media_port'),
-              remoteMediaPort: e.getHeader('variable_remote_media_port')
+              cid: e.getHeader("variable_sip_call_id"),
+              localMediaIp: e.getHeader("variable_local_media_ip"),
+              remoteMediaIp: e.getHeader("variable_remote_media_ip"),
+              localMediaPort: e.getHeader("variable_local_media_port"),
+              remoteMediaPort: e.getHeader("variable_remote_media_port"),
             };
-            if (debug) console.log(`CHANNEL_ANSWER SETTING CACHE FOR ${key} TO ${JSON.stringify(details)}`);
+            if (debug)
+              console.log(
+                `CHANNEL_ANSWER SETTING CACHE FOR ${key} TO ${JSON.stringify(
+                  details
+                )}`
+              );
             db.set(key, details, ttl);
-          } else if (e.getHeader('Event-Name') == 'CHANNEL_DESTROY') {
-            if (e.getHeader('Call-Direction') == 'inbound') {
-              payload += 'HANGUP; ';
-              payload += e.getHeader('Caller-Caller-ID-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+          } else if (e.getHeader("Event-Name") == "CHANNEL_DESTROY") {
+            if (e.getHeader("Call-Direction") == "inbound") {
+              payload += "HANGUP; ";
+              payload += e.getHeader("Caller-Caller-ID-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             } else {
-              payload += 'HANGUP; ';
-              payload += e.getHeader('Caller-Callee-ID-Number') + '; ';
-              payload += e.getHeader('Unique-ID') + '; ';
+              payload += "HANGUP; ";
+              payload += e.getHeader("Caller-Callee-ID-Number") + "; ";
+              payload += e.getHeader("Unique-ID") + "; ";
             }
 
-            db.delete(e.getHeader('Unique-ID'));
-            if (debug) console.log('Session UUID ' + e.getHeader('Unique-ID') + ' has been removed!');
-          } else if (e.getHeader('Event-Name') == 'CUSTOM') {
-            if (e.getHeader('Event-Subclass') === 'sofia::register') {
-              payload += 'REGISTER; ';
-              payload += e.getHeader('from-user') + '; ';
-              payload += e.getHeader('network-ip') + '; ';
-            } else if (e.getHeader('Event-Subclass') === 'sofia::unregister') {
-              payload += 'UNREGISTER; ';
-              payload += e.getHeader('from-user') + '; ';
-              payload += e.getHeader('network-ip') + '; ';
+            db.delete(e.getHeader("Unique-ID"));
+            if (debug)
+              console.log(
+                "Session UUID " +
+                  e.getHeader("Unique-ID") +
+                  " has been removed!"
+              );
+          } else if (e.getHeader("Event-Name") == "CUSTOM") {
+            if (e.getHeader("Event-Subclass") === "sofia::register") {
+              payload += "REGISTER; ";
+              payload += e.getHeader("from-user") + "; ";
+              payload += e.getHeader("network-ip") + "; ";
+            } else if (e.getHeader("Event-Subclass") === "sofia::unregister") {
+              payload += "UNREGISTER; ";
+              payload += e.getHeader("from-user") + "; ";
+              payload += e.getHeader("network-ip") + "; ";
             }
-          } else if (e.getHeader('Event-Name') == 'DTMF') {
-            if (debug) console.log('DTMF EVENT', e);
-            payload += e.getHeader('Event-Name') + ' DIGIT: ' + e.getHeader('DTMF-Digit') + ' DURATION: ' + e.getHeader('DTMF-Duration') + ' FROM:' + e.getHeader('variable_sip_from_user') + ' TO: ' + e.getHeader('variable_sip_req_user');
+          } else if (e.getHeader("Event-Name") == "DTMF") {
+            if (debug) console.log("DTMF EVENT", e);
+            payload +=
+              e.getHeader("Event-Name") +
+              " DIGIT: " +
+              e.getHeader("DTMF-Digit") +
+              " DURATION: " +
+              e.getHeader("DTMF-Duration") +
+              " FROM:" +
+              e.getHeader("variable_sip_from_user") +
+              " TO: " +
+              e.getHeader("variable_sip_req_user");
           } else {
-            payload += e.getHeader('Event-Name') + '; ' + e.getHeader('Channel-Name') + ' (' + e.getHeader('Event-Calling-Function') + ')';
+            payload +=
+              e.getHeader("Event-Name") +
+              "; " +
+              e.getHeader("Channel-Name") +
+              " (" +
+              e.getHeader("Event-Calling-Function") +
+              ")";
           }
 
           if (report_call_events) {
             var message = getCallMessage(e, xcid, payload, hep_id, hep_pass);
-            var message = getCallMessage(e, xcid, JSON.stringify(e), hep_id, hep_pass);
+            var message = getCallMessage(
+              e,
+              xcid,
+              JSON.stringify(e),
+              hep_id,
+              hep_pass
+            );
             callback_preHep(message);
           }
         }
       }
 
       if (report_rtcp_events) {
-        if (e.getHeader('Event-Name') == 'RECV_RTCP_MESSAGE' || e.getHeader('Event-Name') == 'SEND_RTCP_MESSAGE') {
-          if (e.getHeader('Source0-SSRC') || e.getHeader('Source-SSRC')) {
-            if (debug) console.log('Processing RTCP Report...', e);
+        if (
+          e.getHeader("Event-Name") == "RECV_RTCP_MESSAGE" ||
+          e.getHeader("Event-Name") == "SEND_RTCP_MESSAGE"
+        ) {
+          if (e.getHeader("Source0-SSRC") || e.getHeader("Source-SSRC")) {
+            if (debug) console.log("Processing RTCP Report...", e);
             var message = getRTCPMessage(e, xcid, hep_id, hep_pass);
             callback_preHep(message);
           }
@@ -185,8 +252,11 @@ var eslConnect = function (host, port, pass, callback_preHep) {
       }
 
       if (report_qos_events) {
-        if (e.getHeader('Event-Name') == 'CHANNEL_DESTROY') {
-          if (e.getHeader('variable_rtp_use_codec_rate') && e.getHeader('variable_sip_call_id')) {
+        if (e.getHeader("Event-Name") == "CHANNEL_DESTROY") {
+          if (
+            e.getHeader("variable_rtp_use_codec_rate") &&
+            e.getHeader("variable_sip_call_id")
+          ) {
             var message = getQoSMessage(e, xcid, hep_id, hep_pass);
             callback_preHep(message);
           }
@@ -194,109 +264,118 @@ var eslConnect = function (host, port, pass, callback_preHep) {
       }
 
       if (report_custom_events) {
-        if (e.getHeader('Event-Name') == 'CUSTOM') {
-          if (e.getHeader('Unique-ID') && e.getHeader('variable_sip_call_id')) {
-            var message = getCallMessage(e, xcid || e.getHeader('variable_sip_call_id'), hep_id, hep_pass);
+        if (e.getHeader("Event-Name") == "CUSTOM") {
+          if (e.getHeader("Unique-ID") && e.getHeader("variable_sip_call_id")) {
+            var message = getCallMessage(
+              e,
+              xcid || e.getHeader("variable_sip_call_id"),
+              hep_id,
+              hep_pass
+            );
             callback_preHep(message);
           }
         }
       }
-
     });
 };
 
 var getRTCPMessage = function (e, xcid, hep_id, hep_pass) {
-  var call = db.get(e.getHeader('Unique-ID'));
+  var call = db.get(e.getHeader("Unique-ID"));
 
-  if (e.getHeader('Event-Name') == 'RECV_RTCP_MESSAGE') {
+  if (e.getHeader("Event-Name") == "RECV_RTCP_MESSAGE") {
     if (!call.recvSSRC) {
-      call.recvSSRC = e.getHeader('Source0-SSRC');
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+      call.recvSSRC = e.getHeader("Source0-SSRC");
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.recvPackets) {
       call.recvPackets = 0;
     }
-    if (e.getHeader('Sender-Packet-Count')) {
-      packets = parseInt(e.getHeader('Sender-Packet-Count'))  - call.recvPackets;
-      call.recvPackets = parseInt(e.getHeader('Sender-Packet-Count')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Sender-Packet-Count")) {
+      packets = parseInt(e.getHeader("Sender-Packet-Count")) - call.recvPackets;
+      call.recvPackets = parseInt(e.getHeader("Sender-Packet-Count"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.recvOctects) {
       call.recvOctets = 0;
     }
-    if (e.getHeader('Octect-Packet-Count')) {
-      octets = parseInt(e.getHeader('Octect-Packet-Count'))  - call.recvOctets;
-      call.recvOctets = parseInt(e.getHeader('Octect-Packet-Count')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Octect-Packet-Count")) {
+      octets = parseInt(e.getHeader("Octect-Packet-Count")) - call.recvOctets;
+      call.recvOctets = parseInt(e.getHeader("Octect-Packet-Count"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.recvPacketsLost) {
       call.recvPacketsLost = 0;
     }
-    if (e.getHeader('Source0-Lost')) {
-      packetsLost = parseInt(e.getHeader('Source0-Lost'))  - call.recvPacketsLost;
-      call.recvPacketsLost = parseInt(e.getHeader('Source0-Lost')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Source0-Lost")) {
+      packetsLost =
+        parseInt(e.getHeader("Source0-Lost")) - call.recvPacketsLost;
+      call.recvPacketsLost = parseInt(e.getHeader("Source0-Lost"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     var ssrc = call.recvSSRC;
-    var srcIp = call.localMediaIp ? call.localMediaIp : '127.0.0.1';
+    var srcIp = call.localMediaIp ? call.localMediaIp : "127.0.0.1";
     var srcPort = call.localMediaPort ? call.localMediaPort : 0;
-    var dstIp = call.remoteMediaIp ? call.remoteMediaIp : '127.0.0.1';
+    var dstIp = call.remoteMediaIp ? call.remoteMediaIp : "127.0.0.1";
     var dstPort = call.remoteMediaPort ? call.remoteMediaPort : 0;
-    var fractionLost = parseInt(e.getHeader('Source0-Fraction'));
+    var fractionLost = parseInt(e.getHeader("Source0-Fraction"));
     var packetsLost = packetsLost;
-    var highestSeqNo = parseInt(e.getHeader('Source0-Highest-Sequence-Number-Received'));
-    var lsr = parseInt(e.getHeader('Source0-LSR'));
-    var iaJitter = parseFloat(e.getHeader('Source0-Jitter'));
-    var dlsr = parseInt(e.getHeader('Source0-DLSR'));
+    var highestSeqNo = parseInt(
+      e.getHeader("Source0-Highest-Sequence-Number-Received")
+    );
+    var lsr = parseInt(e.getHeader("Source0-LSR"));
+    var iaJitter = parseFloat(e.getHeader("Source0-Jitter"));
+    var dlsr = parseInt(e.getHeader("Source0-DLSR"));
   }
 
-  if (e.getHeader('Event-Name') == 'SEND_RTCP_MESSAGE') {
+  if (e.getHeader("Event-Name") == "SEND_RTCP_MESSAGE") {
     if (!call.sendSSRC) {
-      call.sendSSRC = e.getHeader('SSRC');
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+      call.sendSSRC = e.getHeader("SSRC");
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.sendPackets) {
       call.sendPackets = 0;
     }
-    if (e.getHeader('Sender-Packet-Count')) {
-      packets = parseInt(e.getHeader('Sender-Packet-Count'))  - call.sendPackets;
-      call.sendPackets = parseInt(e.getHeader('Sender-Packet-Count')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Sender-Packet-Count")) {
+      packets = parseInt(e.getHeader("Sender-Packet-Count")) - call.sendPackets;
+      call.sendPackets = parseInt(e.getHeader("Sender-Packet-Count"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.sendOctects) {
       call.sendOctets = 0;
     }
-    if (e.getHeader('Octect-Packet-Count')) {
-      octets = parseInt(e.getHeader('Octect-Packet-Count'))  - call.sendOctets;
-      call.sendOctets = parseInt(e.getHeader('Octect-Packet-Count')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Octect-Packet-Count")) {
+      octets = parseInt(e.getHeader("Octect-Packet-Count")) - call.sendOctets;
+      call.sendOctets = parseInt(e.getHeader("Octect-Packet-Count"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     if (!call.sendPacketsLost) {
       call.sendPacketsLost = 0;
     }
-    if (e.getHeader('Source-Lost')) {
-      packetsLost = parseInt(e.getHeader('Source-Lost')) - call.sendPacketsLost;
-      call.sendPacketsLost = parseInt(e.getHeader('Source-Lost')) ;
-      db.set(e.getHeader('Unique-ID'),call,ttl);
+    if (e.getHeader("Source-Lost")) {
+      packetsLost = parseInt(e.getHeader("Source-Lost")) - call.sendPacketsLost;
+      call.sendPacketsLost = parseInt(e.getHeader("Source-Lost"));
+      db.set(e.getHeader("Unique-ID"), call, ttl);
     }
     var ssrc = call.sendSSRC;
-    var srcIp = call.remoteMediaIp ? call.remoteMediaIp : '127.0.0.1';
+    var srcIp = call.remoteMediaIp ? call.remoteMediaIp : "127.0.0.1";
     var srcPort = call.remoteMediaPort ? call.remoteMediaPort : 0;
-    var dstIp = call.localMediaIp ? call.localMediaIp : '127.0.0.1';
+    var dstIp = call.localMediaIp ? call.localMediaIp : "127.0.0.1";
     var dstPort = call.localMediaPort ? call.localMediaPort : 0;
-    var fractionLost = parseInt(e.getHeader('Source-Fraction'));
+    var fractionLost = parseInt(e.getHeader("Source-Fraction"));
     var packetsLost = packetsLost;
-    var highestSeqNo = parseInt(e.getHeader('Source-Highest-Sequence-Number-Received'));
-    var lsr = parseInt(e.getHeader('Source-LSR'));
-    var iaJitter = parseFloat(e.getHeader('Source-Jitter'));
-    var dlsr = parseInt(e.getHeader('Source-DLSR'));
+    var highestSeqNo = parseInt(
+      e.getHeader("Source-Highest-Sequence-Number-Received")
+    );
+    var lsr = parseInt(e.getHeader("Source-LSR"));
+    var iaJitter = parseFloat(e.getHeader("Source-Jitter"));
+    var dlsr = parseInt(e.getHeader("Source-DLSR"));
   }
 
   var message = {
     rcinfo: {
-      type: 'HEP',
+      type: "HEP",
       version: 3,
-      payload_type: 'JSON',
+      payload_type: "JSON",
       captureId: hep_id,
       capturePass: hep_pass,
       ip_family: 2,
@@ -306,29 +385,31 @@ var getRTCPMessage = function (e, xcid, hep_id, hep_pass) {
       dstIp: dstIp,
       srcPort: srcPort,
       dstPort: dstPort,
-      correlation_id: xcid ? xcid : ''
+      correlation_id: xcid ? xcid : "",
     },
     payload: JSON.stringify({
-      "type": 200,
-      "ssrc": ssrc,
-      "report_count": parseInt(e.getHeader('Event-Sequence')),
-      "report_blocks": [{
-        "source_ssrc": ssrc,
-        "fraction_lost": fractionLost,
-        "packets_lost": packetsLost,
-        "highest_seq_no": highestSeqNo,
-        "lsr": lsr,
-        "ia_jitter": iaJitter,
-        "dlsr": dlsr
-      }],
-      "sender_information": {
-        "packets": packets,
-        "ntp_timestamp_sec": parseInt(e.getHeader('NTP-Most-Significant-Word')),
-        "ntp_timestamp_usec": parseInt(e.getHeader('NTP-Least-Significant-Word')),
-        "rtp_timestamp": parseInt(e.getHeader('RTP-Timestamp')),
-        "octets": octets
-      }
-    })
+      type: 200,
+      ssrc: ssrc,
+      report_count: parseInt(e.getHeader("Event-Sequence")),
+      report_blocks: [
+        {
+          source_ssrc: ssrc,
+          fraction_lost: fractionLost,
+          packets_lost: packetsLost,
+          highest_seq_no: highestSeqNo,
+          lsr: lsr,
+          ia_jitter: iaJitter,
+          dlsr: dlsr,
+        },
+      ],
+      sender_information: {
+        packets: packets,
+        ntp_timestamp_sec: parseInt(e.getHeader("NTP-Most-Significant-Word")),
+        ntp_timestamp_usec: parseInt(e.getHeader("NTP-Least-Significant-Word")),
+        rtp_timestamp: parseInt(e.getHeader("RTP-Timestamp")),
+        octets: octets,
+      },
+    }),
   };
 
   return message;
@@ -337,43 +418,64 @@ var getRTCPMessage = function (e, xcid, hep_id, hep_pass) {
 var getQoSMessage = function (e, xcid, hep_id, hep_pass) {
   var message = {
     rcinfo: {
-      type: 'HEP',
+      type: "HEP",
       version: 3,
-      payload_type: 'JSON',
+      payload_type: "JSON",
       captureId: hep_id,
       capturePass: hep_pass,
       ip_family: 2,
       protocol: 17,
       proto_type: 34,
-      mos: parseFloat(e.getHeader('variable_rtp_audio_in_mos')),
-      srcIp: e.getHeader('variable_local_media_ip') ? e.getHeader('variable_local_media_ip') : '127.0.0.1',
-      dstIp: e.getHeader('variable_remote_media_ip') ? e.getHeader('variable_remote_media_ip') : '127.0.0.1',
-      srcPort: parseInt(e.getHeader('variable_local_media_port')) ? parseInt(e.getHeader('variable_local_media_port')) : 0,
-      dstPort: parseInt(e.getHeader('variable_remote_media_port')) ? parseInt(e.getHeader('variable_remote_media_port')) : 0,
-      correlation_id: xcid ? xcid : ''
+      mos: parseFloat(e.getHeader("variable_rtp_audio_in_mos")),
+      srcIp: e.getHeader("variable_local_media_ip")
+        ? e.getHeader("variable_local_media_ip")
+        : "127.0.0.1",
+      dstIp: e.getHeader("variable_remote_media_ip")
+        ? e.getHeader("variable_remote_media_ip")
+        : "127.0.0.1",
+      srcPort: parseInt(e.getHeader("variable_local_media_port"))
+        ? parseInt(e.getHeader("variable_local_media_port"))
+        : 0,
+      dstPort: parseInt(e.getHeader("variable_remote_media_port"))
+        ? parseInt(e.getHeader("variable_remote_media_port"))
+        : 0,
+      correlation_id: xcid ? xcid : "",
     },
     payload: JSON.stringify({
-      "CORRELATION_ID": xcid ? xcid : e.getHeader('variable_sip_call_id'),
-      "RTP_SIP_CALL_ID": xcid ? xcid : e.getHeader('variable_sip_call_id'),
-      "JITTER": (parseInt(e.getHeader('variable_rtp_audio_in_jitter_min_variance')) + parseInt(e.getHeader('variable_rtp_audio_in_jitter_max_variance'))) / 2,
-      "REPORT_TS": parseInt(e.getHeader('Event-Date-Timestamp')),
-      "TL_BYTE": parseInt(e.getHeader('variable_rtp_audio_in_media_bytes')) + parseInt(e.getHeader('variable_rtp_audio_out_media_bytes')),
-      "TOTAL_PK": parseInt(e.getHeader('variable_rtp_audio_in_packet_count')) + parseInt(e.getHeader('variable_rtp_audio_out_packet_count')),
-      "PACKET_LOSS": parseInt(e.getHeader('variable_rtp_audio_in_skip_packet_count')) + parseInt(e.getHeader('variable_rtp_audio_out_skip_packet_count')),
-      "MAX_JITTER": parseFloat(e.getHeader('variable_rtp_audio_in_jitter_max_variance')),
-      "MIN_JITTER": parseFloat(e.getHeader('variable_rtp_audio_in_jitter_min_variance')),
-      "DELTA": parseFloat(e.getHeader('variable_rtp_audio_in_mean_interval')),
-      "MOS": parseFloat(e.getHeader('variable_rtp_audio_in_mos')),
-      "SRC_IP": e.getHeader('variable_advertised_media_ip'),
-      "SRC_PORT": parseInt(e.getHeader('variable_local_media_port')),
-      "DST_IP": e.getHeader('variable_remote_media_ip'),
-      "DST_PORT": parseInt(e.getHeader('variable_remote_media_port')),
-      "CODEC_PT": parseInt(e.getHeader('variable_rtp_audio_recv_pt')),
-      "PTIME": parseInt(e.getHeader('variable_rtp_use_codec_ptime')),
-      "CLOCK": parseInt(e.getHeader('variable_rtp_use_codec_rate')),
-      "CODEC_NAME": e.getHeader('variable_rtp_use_codec_name'),
-      "TYPE": e.getHeader('Event-Name')
-    })
+      CORRELATION_ID: xcid ? xcid : e.getHeader("variable_sip_call_id"),
+      RTP_SIP_CALL_ID: xcid ? xcid : e.getHeader("variable_sip_call_id"),
+      JITTER:
+        (parseInt(e.getHeader("variable_rtp_audio_in_jitter_min_variance")) +
+          parseInt(e.getHeader("variable_rtp_audio_in_jitter_max_variance"))) /
+        2,
+      REPORT_TS: parseInt(e.getHeader("Event-Date-Timestamp")),
+      TL_BYTE:
+        parseInt(e.getHeader("variable_rtp_audio_in_media_bytes")) +
+        parseInt(e.getHeader("variable_rtp_audio_out_media_bytes")),
+      TOTAL_PK:
+        parseInt(e.getHeader("variable_rtp_audio_in_packet_count")) +
+        parseInt(e.getHeader("variable_rtp_audio_out_packet_count")),
+      PACKET_LOSS:
+        parseInt(e.getHeader("variable_rtp_audio_in_skip_packet_count")) +
+        parseInt(e.getHeader("variable_rtp_audio_out_skip_packet_count")),
+      MAX_JITTER: parseFloat(
+        e.getHeader("variable_rtp_audio_in_jitter_max_variance")
+      ),
+      MIN_JITTER: parseFloat(
+        e.getHeader("variable_rtp_audio_in_jitter_min_variance")
+      ),
+      DELTA: parseFloat(e.getHeader("variable_rtp_audio_in_mean_interval")),
+      MOS: parseFloat(e.getHeader("variable_rtp_audio_in_mos")),
+      SRC_IP: e.getHeader("variable_advertised_media_ip"),
+      SRC_PORT: parseInt(e.getHeader("variable_local_media_port")),
+      DST_IP: e.getHeader("variable_remote_media_ip"),
+      DST_PORT: parseInt(e.getHeader("variable_remote_media_port")),
+      CODEC_PT: parseInt(e.getHeader("variable_rtp_audio_recv_pt")),
+      PTIME: parseInt(e.getHeader("variable_rtp_use_codec_ptime")),
+      CLOCK: parseInt(e.getHeader("variable_rtp_use_codec_rate")),
+      CODEC_NAME: e.getHeader("variable_rtp_use_codec_name"),
+      TYPE: e.getHeader("Event-Name"),
+    }),
   };
   return message;
 };
@@ -381,21 +483,21 @@ var getQoSMessage = function (e, xcid, hep_id, hep_pass) {
 var getCallMessage = function (e, xcid, payload, hep_id, hep_pass) {
   var message = {
     rcinfo: {
-      type: 'HEP',
+      type: "HEP",
       version: 3,
-      payload_type: 'JSON',
+      payload_type: "JSON",
       captureId: hep_id,
       capturePass: hep_pass,
       ip_family: 2,
       protocol: 17,
       proto_type: 100,
-      srcIp: e.getHeader('FreeSWITCH-IPv4'),
-      dstIp: e.getHeader('FreeSWITCH-IPv4'),
+      srcIp: e.getHeader("FreeSWITCH-IPv4"),
+      dstIp: e.getHeader("FreeSWITCH-IPv4"),
       srcPort: 0,
       dstPort: 0,
-      correlation_id: xcid ? xcid : e.getHeader('variable_sip_call_id')
+      correlation_id: xcid ? xcid : e.getHeader("variable_sip_call_id"),
     },
-    payload: payload
+    payload: payload,
   };
 
   return message;

--- a/hep-client.js
+++ b/hep-client.js
@@ -33,6 +33,10 @@ module.exports = {
     socket = getSocket("udp4");
   },
   preHep: function (message) {
+    if (!message) {
+      return;
+    }
+
     var rcinfo = message.rcinfo;
     var msg = message.payload;
     if (

--- a/hep-client.js
+++ b/hep-client.js
@@ -8,12 +8,12 @@ Giacomo Vacca <giacomo.vacca@gmail.com>
 Federico Cabibbu <federico.cabiddu@gmail.com>
 */
 
-var HEPjs = require('hep-js');
-var dgram = require('dgram');
+var HEPjs = require("hep-js");
+var dgram = require("dgram");
 var socket = dgram.createSocket("udp4");
 
-var debug = false; 
-var stats = {rcvd: 0, parsed: 0, hepsent: 0, err: 0, heperr: 0 }; 
+var debug = false;
+var stats = { rcvd: 0, parsed: 0, hepsent: 0, err: 0, heperr: 0 };
 
 var hep_server;
 var hep_port;
@@ -23,45 +23,49 @@ var hep_id;
 var socket;
 
 module.exports = {
-  init:function(config) {
+  init: function (config) {
     hep_server = config.HEP_SERVER;
     hep_port = config.HEP_PORT;
     hep_pass = config.HEP_PASS;
     hep_id = config.HEP_ID;
     debug = config.debug;
     socket = dgram.createSocket("udp4");
-    socket = getSocket('udp4'); 
+    socket = getSocket("udp4");
   },
-  preHep:function(message) {
+  preHep: function (message) {
     var rcinfo = message.rcinfo;
     var msg = message.payload;
-    if (rcinfo.correlation_id == null || !(rcinfo.correlation_id.toString().length)) return;
+    if (
+      rcinfo.correlation_id == null ||
+      !rcinfo.correlation_id.toString().length
+    )
+      return;
     if (debug) console.log(msg);
     stats.rcvd++;
 
     var hrTime = process.hrtime();
     var datenow = new Date().getTime();
-    rcinfo.time_sec = Math.floor( datenow / 1000);
-    rcinfo.time_usec = datenow - (rcinfo.time_sec*1000);
+    rcinfo.time_sec = Math.floor(datenow / 1000);
+    rcinfo.time_usec = datenow - rcinfo.time_sec * 1000;
 
     if (debug) console.log(rcinfo);
     if (!msg.length || msg == "") return;
-    sendHEP3(msg, rcinfo);	
+    sendHEP3(msg, rcinfo);
   },
-  getStats:function() {
+  getStats: function () {
     return stats;
-  }
+  },
 };
 
 var getSocket = function (type) {
   if (undefined === socket) {
     socket = dgram.createSocket(type);
-    socket.on('error', socketErrorHandler);
+    socket.on("error", socketErrorHandler);
 
     /**
-    * Handles socket's 'close' event,
-    * recover socket in case of unplanned closing.
-    */
+     * Handles socket's 'close' event,
+     * recover socket in case of unplanned closing.
+     */
     var socketCloseHandler = function () {
       if (socketUsers > 0) {
         socket = undefined;
@@ -69,28 +73,41 @@ var getSocket = function (type) {
         getSocket(type);
       }
     };
-    socket.on('close', socketCloseHandler);
+    socket.on("close", socketCloseHandler);
   }
   return socket;
-}
+};
 
-var sendHEP3 = function(msg,rcinfo){
+var sendHEP3 = function (msg, rcinfo) {
   if (rcinfo && msg) {
     try {
-      if (debug) console.log('Sending HEP3 Packet to '+ hep_server + ':' + hep_port + '...');
-      if (! typeof msg === 'string' || ! msg instanceof String) msg = JSON.stringify(msg);
-      var hep_message = HEPjs.encapsulate(msg.toString(),rcinfo);
+      if (debug)
+        console.log(
+          "Sending HEP3 Packet to " + hep_server + ":" + hep_port + "..."
+        );
+      if (!typeof msg === "string" || !msg instanceof String)
+        msg = JSON.stringify(msg);
+      var hep_message = HEPjs.encapsulate(msg.toString(), rcinfo);
       stats.parsed++;
       if (hep_message && hep_message.length) {
-        socket.send(hep_message, 0, hep_message.length, hep_port, hep_server, function(err) {
-          stats.hepsent++;
-        });
-      } else { console.log('HEP Parsing error!'); stats.heperr++; }
-    } 
-    catch (e) {
-      console.log('HEP3 Error sending!');
+        socket.send(
+          hep_message,
+          0,
+          hep_message.length,
+          hep_port,
+          hep_server,
+          function (err) {
+            stats.hepsent++;
+          }
+        );
+      } else {
+        console.log("HEP Parsing error!");
+        stats.heperr++;
+      }
+    } catch (e) {
+      console.log("HEP3 Error sending!");
       console.log(e);
       stats.heperr++;
     }
   }
-}
+};

--- a/hepipe.js
+++ b/hepipe.js
@@ -8,40 +8,39 @@ Giacomo Vacca <giacomo.vacca@gmail.com>
 Federico Cabibbu <federico.cabiddu@gmail.com>
 */
 
-var version = 0.3
-console.log("HEPIPE v"+version+" (http://sipcapture.org)");
+var version = 0.3;
+console.log("HEPIPE v" + version + " (http://sipcapture.org)");
 console.log("Press CTRL-C to Exit...");
 
-var config = require('./config.js');
+var config = require("./config.js");
 
 if (config.hep_config) {
-  var hep_client = require('./hep-client.js');
+  var hep_client = require("./hep-client.js");
   hep_client.init(config.hep_config);
-}
-else {
-  console.log('Must provide HEP configuration');
+} else {
+  console.log("Must provide HEP configuration");
   exit;
 }
 
 if (config.logs_config) {
-  var log_client = require('./log-client.js');
+  var log_client = require("./log-client.js");
   log_client.watchFiles(config.logs_config, hep_client.preHep);
 }
 
 if (config.esl_config) {
-  var esl_client = require('./esl-client.js');
+  var esl_client = require("./esl-client.js");
   esl_client.connect(config.esl_config, hep_client.preHep);
 }
 
 if (config.janus_config) {
-  var janus_client = require('./janus-client.js');
+  var janus_client = require("./janus-client.js");
   janus_client.connect(config.janus_config, hep_client.preHep);
 }
 
 var exit = false;
-process.on('SIGINT', function() {
+process.on("SIGINT", function () {
   console.log();
-  console.log('Stats:', hep_client.getStats());
+  console.log("Stats:", hep_client.getStats());
   if (exit) {
     console.log("Exiting...");
     process.exit();
@@ -50,6 +49,6 @@ process.on('SIGINT', function() {
     exit = true;
     setTimeout(function () {
       exit = false;
-    }, 2000)
+    }, 2000);
   }
 });

--- a/janus-client.js
+++ b/janus-client.js
@@ -1,15 +1,15 @@
 /*
-*       HEPIPE-JANUS 0.1
-*       Meetecho Janus Event API to HEP/EEP Utility
-*       Copyright 2016 QXIP BV (http://qxip.net)
-* Edited by:
-* Giacomo Vacca <giacomo.vacca@gmail.com>
-* Federico Cabibbu <federico.cabiddu@gmail.com>
-*/
+ *       HEPIPE-JANUS 0.1
+ *       Meetecho Janus Event API to HEP/EEP Utility
+ *       Copyright 2016 QXIP BV (http://qxip.net)
+ * Edited by:
+ * Giacomo Vacca <giacomo.vacca@gmail.com>
+ * Federico Cabibbu <federico.cabiddu@gmail.com>
+ */
 
-var http = require('http');
+var http = require("http");
 
-var Receptacle = require('receptacle');
+var Receptacle = require("receptacle");
 var db = new Receptacle({ max: 1024 });
 
 var debug = false;
@@ -23,7 +23,7 @@ var api_port;
 var preHep;
 
 module.exports = {
-  connect:function(config, callback_preHep) {
+  connect: function (config, callback_preHep) {
     hep_id = config.HEP_ID;
     hep_pass = config.HEP_PASS;
     api_port = config.API_PORT;
@@ -31,64 +31,67 @@ module.exports = {
     debug = config.debug;
 
     /* HTTP API Receiver */
-    http.createServer(function (req, res) {
-      var body = "";
-      req.on('data', function (chunk) {
-        body += chunk;
-      });
-      req.on('end', function () {
-        // console.log(body);
-        // Parse Event
-        body = JSON.parse(body);
-        if(Array.isArray(body)) {
-          for(var i in body)
-            processJanusEvent(body[i]);
-        } else {
-          processJanusEvent(body);
-        }
-        res.writeHead(200);
-        res.end();
-      });
-    }).listen(api_port);
-  }
+    http
+      .createServer(function (req, res) {
+        var body = "";
+        req.on("data", function (chunk) {
+          body += chunk;
+        });
+        req.on("end", function () {
+          // console.log(body);
+          // Parse Event
+          body = JSON.parse(body);
+          if (Array.isArray(body)) {
+            for (var i in body) processJanusEvent(body[i]);
+          } else {
+            processJanusEvent(body);
+          }
+          res.writeHead(200);
+          res.end();
+        });
+      })
+      .listen(api_port);
+  },
 };
 
 /* JANUS Event Handler */
 function processJanusEvent(e) {
   // do stuff
-  if (debug) console.log('Janus Session-ID: ' + e.session_id);
-  if (debug) console.log('Janus Event Type: ' + e.type);
+  if (debug) console.log("Janus Session-ID: " + e.session_id);
+  if (debug) console.log("Janus Event Type: " + e.type);
 
   // No CID no Party! Check handle_id to Call-ID association, Skip if none available
   if (db) {
     if (db.get(e.handle_id)) {
-      if (debug) console.log('FOUND HANDLE ID!', db.get(e.handle_id).cid);
+      if (debug) console.log("FOUND HANDLE ID!", db.get(e.handle_id).cid);
       var xcid = db.get(e.handle_id).cid;
     }
-  } else { var xcid = e.handle_id; }
+  } else {
+    var xcid = e.handle_id;
+  }
 
   /* EVENT LOGGER */
   if (log) {
     // Log Events to HEP Message
-    if(e.type == 64) {
+    if (e.type == 64) {
       // Save association Handle-ID > SIP Call-ID
-      if(e.event.data['call-id']) {
-        db.set(e.handle_id, {cid: e.event.data['call-id']}, ttl);
-        xcid = e.event.data['call-id'];
+      if (e.event.data["call-id"]) {
+        db.set(e.handle_id, { cid: e.event.data["call-id"] }, ttl);
+        xcid = e.event.data["call-id"];
       }
 
-      var ip = '127.0.0.1';
+      var ip = "127.0.0.1";
 
-      if(e.event.data['sip']) {
+      if (e.event.data["sip"]) {
         // Send as SIP type
-        var payload = e.event.data['sip'];
+        var payload = e.event.data["sip"];
 
         // Format HEP Header
         var message = {
           rcinfo: {
-            type: 'HEP',
+            type: "HEP",
             version: 3,
-            payload_type: 'SIP',
+            payload_type: "SIP",
             captureId: hep_id,
             capturePass: hep_pass,
             ip_family: 2,
@@ -98,24 +101,24 @@ function processJanusEvent(e) {
             dstIp: ip,
             srcPort: 0,
             dstPort: 0,
-            correlation_id: xcid ? xcid : e.handle_id
+            correlation_id: xcid ? xcid : e.handle_id,
           },
-          payload: payload
+          payload: payload,
         };
 
         // Prepare for shipping!
         preHep(message);
       } else {
-        // Send as Log type 
-        var payload = e.timestamp + ': ';
+        // Send as Log type
+        var payload = e.timestamp + ": ";
         payload += JSON.stringify(e.event);
 
         // Format HEP Header
         var message = {
           rcinfo: {
-            type: 'HEP',
+            type: "HEP",
             version: 3,
-            payload_type: 'JSON',
+            payload_type: "JSON",
             captureId: hep_id,
             capturePass: hep_pass,
             ip_family: 2,
@@ -125,9 +128,9 @@ function processJanusEvent(e) {
             dstIp: ip,
             srcPort: 0,
             dstPort: 0,
-            correlation_id: xcid ? xcid : e.handle_id
+            correlation_id: xcid ? xcid : e.handle_id,
           },
-          payload: payload
+          payload: payload,
         };
 
         // Prepare for shipping!


### PR DESCRIPTION
Hepipe fails to start if the telephony service was already active and processing calls before Hepipe comes online. This is because it's receiving RTCP events for calls that don't exist in it's database.

This PR fixes that by ignore RTCP events if the call doesn't exist. The fix follows the suggestion outlined here:
https://github.com/sipcapture/hepipe.js/issues/28